### PR TITLE
Upload `SKILLS.md` derived from personal project blog

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,165 @@
+# Chris Bergeron - Skills Inventory
+
+Derived from deep review of [chrisbergeron.com](https://chrisbergeron.com) — all blog posts, /projects, and /about
+
+---
+
+## Meta Skills (demonstrated across multiple projects)
+
+| # | Skill | Count | Evidence |
+|---|-------|-------|----------|
+| 1 | **Systems Integration** | 14 | DashPC (multimedia+nav+diagnostics+wireless in a car), Vault TOTP (Vault+Consul+SSH+TOTP apps), Thunderbolt NAS (Linux+TB3+M1+NVMe), Magic Mirror (Pi+modules+APIs), Roomba CLI (Node.js+REST+LAN+MagicMirror), Pi Garage Opener (Pi+relay+API+iPhone), Pi Appliance Notifier (vibration sensor+Pi+SMS), ESXi Dashboard (VMware+Grafana+metrics), DSSC Controller (PIC+MAX-232+relay+shell scripts), Uptime Monitor (GitHub Actions+Svelte+issue tracking), NFC Reader (USB HID+Python+NFC tags+foam cube), PiHole (DNS+Pi+network filtering), Quadcopter (ESC+flight controller+motors+LiPo+frame), Kitchen Reno (capacitive copper touch backsplash) |
+| 2 | **Technical Writing / Documentation** | 12 | Every blog post; DSSC installation manual; detailed benchmarking methodology in TB NAS and RAID-0 posts; Schema.org analysis; Own Yourself branding guide; structured how-tos with photos and terminal output |
+| 3 | **Reverse Engineering** | 7 | NFC Reader (decoded USB HID Report Descriptor via lsusb/usbhid-dump), Maple Ridge TB4 (binary firmware analysis with dd/od/strings/binwalk), Roomba CLI (reverse-engineered LAN protocol via dorita980), DashPC (vehicle electrical systems), Vault TOTP (modulo arithmetic to constrain TOTP codes to valid port ranges), Nvidia Shield SSD (device disassembly), Overhead Projector Hack |
+| 4 | **Performance Engineering / Benchmarking** | 6 | Thunderbolt NAS (iperf3, systematic PHY speed verification via sysfs), RAID-0 DAS (3.74 GB/s validated, cable length signal integrity testing), Maple Ridge TB4 (iperf3 bidirectional, kernel module analysis), Hypermiling (50+ MPG through vehicle optimization), chrisbergeron.com (PageSpeed 100), Uptime Monitor (response time trending) |
+| 5 | **Prototyping / Rapid Iteration** | 6 | Quadcopter (aluminum towel rod frame, iterating on commercial limitations), NFC Time Tracker (foam cube + sticker tags), Pi Project Box (vintage alarm clock housing), Metalcasting Furnace ("2 Bucks Furnace" design), Homebrew Generator (lawnmower engine + alternator), Momentary Window Button (555 timer circuit from newsgroup research) |
+| 6 | **Cost Optimization / Resourcefulness** | 6 | NFC Reader ($6 thrift store find), Pi Display Case (repurposed materials), Kitchen Countertops (Craigslist freebie), Metalcasting Furnace (budget build), Homebrew Generator (scavenged parts), Quadcopter (household materials for frame) |
+| 7 | **Entrepreneurship / Business** | 5 | Dashwerks Inc (founded, operated 2003-2006, O'Reilly featured), Gridforge (security consulting firm), Chris Bergeron Consulting Group (DevSecOps), The Holding Company LLC (asset management), METAcrypt (blockchain venture) |
+| 8 | **Troubleshooting / Root Cause Analysis** | 5 | Vault TOTP (port overflow constraints, timing edge cases), TB NAS (asymmetric bandwidth discovery - 20Gbps vs expected 40Gbps), Maple Ridge TB4 (motherboard pin shorting workaround for PCIe recognition), Schema.org (identified Google validator bug vs spec), Honda Insight (battery diagnostics) |
+| 9 | **Graphic Design / Branding** | 4 | CB brand logo, Own Yourself article (Affinity Photo/Designer, color theory, Paletter 4), 8-bit avatar creation, consistent cross-platform visual identity |
+| 10 | **Regulatory / Compliance Navigation** | 2 | Ethanol Still (TTB bureau consultation before build), Gridforge (penetration testing within legal frameworks) |
+
+---
+
+## Technical Skills (descending by frequency)
+
+| # | Skill | Count | Projects |
+|---|-------|-------|----------|
+| 1 | **Linux System Administration** | 16 | DashPC, Thunderbolt NAS, RAID-0 DAS, Maple Ridge TB4, Vault TOTP, Roomba CLI, NFC Reader, Uptime Monitor, VQGAN Art, Magic Mirror, Launch PWA, PiHole, Pi Garage Opener, Pi Appliance Notifier, NZBget plugins, ESXi Dashboard |
+| 2 | **Bash / Shell Scripting** | 9 | Vault TOTP (timing logic, port rotation), Roomba CLI, NFC Reader, Uptime Monitor, Thunderbolt NAS, RAID-0 DAS, Maple Ridge TB4, DSSC Controller, DashPC |
+| 3 | **Raspberry Pi / SBC** | 9 | Magic Mirror, Pi Garage Opener, Pi Appliance Notifier, Pi Display Case, Pi Project Box, PiHole, Pi Zero Cluster, NFC Reader, Grow Stand |
+| 4 | **Python** | 8 | NZBget ES Plugin, NZBget MySQL Plugin, NFC Reader (ported Python 2 library to 3), Vault TOTP, VQGAN Art, Thunderbolt NAS, Magic Mirror, AI GAN Art |
+| 5 | **Hardware / Electronics** | 8 | Momentary Window Button (555 timer/resistor/capacitor), DSSC Controller (PIC16F28/MAX-232/relay), Quadcopter, DashPC, Metalcasting Furnace, Nvidia Shield SSD, Projector Hack, M1 HUD |
+| 6 | **Web Development (HTML/CSS/JS)** | 8 | chrisbergeron.com (PageSpeed 100), Dashwerks, HoldingCo, Debris Art, METAcrypt, Next Rocket Launch, Firefox Start Page, Consulting site |
+| 7 | **JavaScript / Node.js** | 7 | Roomba CLI (dorita980/rest980/Express.js), Uptime Monitor, Magic Mirror, MMM-NextRocketLaunch, VQGAN Art, Launch PWA, Plex BitBar |
+| 8 | **Networking** | 7 | Vault TOTP (dynamic port binding), TB NAS (point-to-point TB bridging + Ethernet), RAID-0 DAS, Maple Ridge TB4 (iperf3), Roomba CLI (LAN), Uptime Monitor, PiHole (DNS) |
+| 9 | **IoT / Home Automation** | 7 | Roomba CLI, Pi Garage Opener (relay+API+phone), Pi Appliance Notifier (vibration sensor+SMS), PiHole, Magic Mirror, NFC Reader, Kitchen Touch Backsplash (capacitive copper tiles) |
+| 10 | **Automotive / Vehicle Systems** | 6 | DashPC (multimedia/nav/diagnostics/wireless), Dashwerks Inc, Momentary Window Button, Honda Insight Battery, Hypermiling (50+ MPG), EV Conversion |
+| 11 | **Woodworking / Fabrication** | 6 | Pi Display Case (wood+glass), Bed (custom frame), Kitchen Reno (open-concept, recessed lighting, moulding), Garage Cabinets, Library/Study (ceiling medallion, paint finishing), Bathroom Shelves (built-in shower cavity) |
+| 12 | **REST APIs** | 5 | Roomba CLI (built REST server with Express.js), Vault TOTP, Uptime Monitor (GitHub API), Launch PWA (theSpaceDev API), Plex BitBar (Plex API) |
+| 13 | **Git / GitHub** | 5 | Uptime Monitor, VQGAN Art, Launch PWA, Roomba CLI, Vault TOTP |
+| 14 | **Storage Architecture (NVMe / RAID / NAS)** | 4 | RAID-0 DAS (striped across TB4 buses, 3.74 GB/s), TB NAS (20-40 Gbps, 20+ years archival), Maple Ridge TB4, Nvidia Shield SSD |
+| 15 | **Thunderbolt / PCIe** | 4 | TB NAS (Titan Ridge card, pin-shorting workaround), RAID-0 DAS (signal integrity over 2m active cables), Maple Ridge TB4 (JHL8540 controller, sysfs inspection), Pushover Desktop |
+| 16 | **Static Site Generation (Hexo)** | 4 | chrisbergeron.com (DevOps methodology: dev branches, production promotion), Launch PWA, VQGAN Art, Magic Mirror |
+| 17 | **Security** | 4 | Vault TOTP (MFA, dynamic ports, fail2ban), SSH hardening, Gridforge (pen testing, vuln assessment), Uptime Monitor |
+| 18 | **Grafana / Observability** | 3 | ESXi Dashboard, Management Dashboard, NZBget MySQL Plugin |
+| 19 | **Machine Learning / AI** | 3 | VQGAN+CLIP (multi-model orchestration, prompt engineering, GPU compute, TensorFlow+PyTorch), AI Generated Art, Debris Art (NFT pipeline to OpenSea) |
+| 20 | **CI/CD / GitHub Actions** | 3 | Uptime Monitor (5-min cron, auto issue creation/closure), Launch PWA, VQGAN Art |
+| 21 | **macOS** | 3 | RAID-0 DAS, Pushover Desktop (iOS app compat layer on Apple Silicon), Plex BitBar |
+| 22 | **MySQL / Databases** | 3 | NZBget MySQL Plugin (PyMySQL), ESXi Dashboard, Grafana dashboards |
+| 23 | **USB / HID Protocols** | 2 | NFC Reader (USB descriptor parsing, HID report decoding, lsusb/usbhid-dump), DashPC |
+| 24 | **Microcontrollers** | 2 | DSSC Controller (PIC16F28, MAX-232 IC), Momentary Window Button (555 timer) |
+| 25 | **PCB Design (Eagle)** | 2 | DSSC Controller, Momentary Window Button |
+| 26 | **ElasticSearch** | 2 | NZBget ES Plugin, infrastructure monitoring |
+| 27 | **Docker / Containers** | 2 | Infrastructure projects, Mattermost/Traefik stack |
+| 28 | **Blockchain / Crypto** | 2 | METAcrypt, NFT art (OpenSea marketplace) |
+| 29 | **WordPress** | 2 | HoldingCo site, Consulting site |
+| 30 | **VMware / Virtualization** | 2 | ESXi Dashboard, home lab |
+| 31 | **PWA Development** | 2 | Next Rocket Launch (mobile-first, offline, lightweight), Uptime Monitor |
+| 32 | **Graphic Design (Affinity Photo/Designer)** | 2 | CB brand logo, Own Yourself branding guide (color theory, Paletter 4) |
+| 33 | **Binary Analysis** | 1 | Maple Ridge TB4 (dd, od, strings, binwalk on NVM firmware) |
+| 34 | **Drone / Flight Controllers** | 1 | Quadcopter (SimonK ESC, Multi-Wii, SunnySky motors, carbon fiber) |
+| 35 | **HashiCorp Stack (Vault/Consul)** | 1 | Vault TOTP (Consul service discovery, DNS steering, Vault TOTP engine) |
+| 36 | **NFC / RFID** | 1 | NFC Time Tracker (NTAG format read/write, tag lifecycle events) |
+| 37 | **Metalcasting** | 1 | Furnace (ceramic refractories, temp management, aluminum casting) |
+| 38 | **Alternative Energy** | 1 | Generator (engine+alternator+belt/pulley, DC-AC inverter) |
+| 39 | **Distillation / Process Engineering** | 1 | Ethanol Still (Charles 803, fermentation, TTB compliance) |
+| 40 | **Schema.org / SEO** | 1 | JSON-LD implementation, Google validator bug identification |
+| 41 | **Wearable Tech** | 1 | M1 HUD (TekGear 320x200 composite video monocular) |
+| 42 | **Sensor Integration** | 1 | Pi Appliance Notifier (vibration detection for laundry completion) |
+
+---
+
+## Project Index
+
+### Software
+| Project | Summary |
+|---------|---------|
+| Dynamic SSH Ports with Vault TOTP | Vault+Consul orchestration rotating SSH ports every 30s via TOTP |
+| NFC Time Tracker | $6 thrift store NFC reader reverse-engineered into project time tracker with foam cube UX |
+| iRobot Roomba CLI | Express.js REST server wrapping dorita980 SDK for terminal-based vacuum control |
+| Uptime Monitor | GitHub Actions SRE: 5-min cron checks, auto-incident creation, Svelte status page |
+| NZBget ElasticSearch Plugin | Python plugin indexing download history into ES |
+| NZBget MySQL Plugin | Python plugin recording downloads to MySQL for Grafana dashboards |
+| Plex BitBar Plugin | macOS menubar showing currently playing Plex media |
+| MMM-NextRocketLaunch | MagicMirror module consuming theSpaceDev API for launch countdowns |
+| VQGAN+CLIP Art | Multi-model ML pipeline (VQGAN+CLIP+TensorFlow+PyTorch) with NFT marketplace deployment |
+| Custom Firefox Start Page | Personal browser homepage replacing default UX |
+
+### Hardware & Infrastructure
+| Project | Summary |
+|---------|---------|
+| Thunderbolt NAS | Point-to-point TB3 bridge (Titan Ridge on Supermicro Xeon) to M1, pin-shorting hardware workaround, 20 Gbps validated |
+| RAID-0 DAS | Dual TB4 NVMe enclosures striped for 3.74 GB/s video editing scratch; signal integrity tested over 2m active cables |
+| Maple Ridge TB4 Card | Hands-on Linux kernel module testing (JHL8540), firmware binary analysis (binwalk/dd/od), sysfs deep dive |
+| ESXi Dashboard | Grafana-based VMware hypervisor performance monitoring |
+| PiHole | Network-wide DNS-level ad blocking |
+| Pi Zero Cluster | Networked cluster of Pi Zero units |
+
+### Raspberry Pi
+| Project | Summary |
+|---------|---------|
+| Magic Mirror | Smart mirror integrating time, weather, news, custom rocket launch module |
+| Pi Garage Door Opener | Relay module + custom API + iPhone app for remote garage control |
+| Pi Appliance Notifier | Vibration sensor detecting washer/dryer completion, triggering SMS alerts |
+| Pi Display Case | Handmade wood + glass multi-Pi housing |
+| Pi Project Box | Vintage alarm clock converted to Pi enclosure with rotary encoder and haptic buttons |
+
+### Automotive
+| Project | Summary |
+|---------|---------|
+| The DashPC | Pioneering in-dash Linux computer (1999): multimedia, navigation, engine diagnostics, wireless — 3x Slashdot frontpage |
+| Dashwerks, Inc. | Commercialized DashPC concept (2003-2006), O'Reilly Release 2.0 feature, multiple book citations |
+| DSSC Controller | Custom PCB (Eagle): PIC16F28 + MAX-232 managing vehicle ignition-to-computer startup sequencing |
+| Honda Insight MIMA | Hybrid battery pack diagnostics and replacement |
+| EV Conversion | Gasoline-to-electric vehicle retrofit (motor, batteries, speed controller) |
+| Hypermiling | Systematic fuel efficiency optimization achieving 50+ MPG |
+
+### Electronics & Fabrication
+| Project | Summary |
+|---------|---------|
+| Momentary Window Button | 555 timer circuit designed from engineering newsgroup research |
+| Towelrod Quadcopter | DIY drone: aluminum towel rod frame, SimonK ESC, Multi-Wii FC, SunnySky motors, carbon fiber props |
+| Metalcasting Furnace | Budget aluminum melting furnace with ceramic refractories |
+| Homebrew Generator | Lawnmower engine + alternator + belt/pulley system with DC-AC inverter |
+| Ethanol Still | Corn-based fuel distillation (Charles 803 design), TTB bureau pre-approval |
+| M1 Wearable HUD | TekGear composite video monocular (320x200) exploration |
+| Kitchen Touch Backsplash | Capacitive copper tiles with touch-activated LED lighting |
+
+### Web Properties
+| Project | Summary |
+|---------|---------|
+| chrisbergeron.com | Personal tech blog (Hexo), PageSpeed 100, DevOps workflow with dev/prod branches |
+| dashpc.org | Archival site for the original automotive Linux project |
+| debris-art.com | AI-generated artwork gallery and NFT showcase |
+| holdingco.com | Asset management company (WordPress + Affinity design) |
+| METAcrypt.io | Blockchain venture (in development) |
+| Next Rocket Launch | Mobile-first PWA for Kennedy Space Center launch countdowns |
+
+---
+
+## Professional Summary
+
+- **Titles**: Senior Infrastructure Architect, Senior DevOps Engineer, DevSecOps Consultant
+- **Experience**: 25+ years in technology (started on a TRS-80 at age 13)
+- **Companies Founded**: Dashwerks Inc, Gridforge, Chris Bergeron Consulting Group, The Holding Company LLC, METAcrypt
+- **Press**: O'Reilly Release 2.0 Magazine, Hacker News (#4), Slashdot frontpage (3x), cited in multiple O'Reilly/Wiley books
+- **Platforms**: Every major computing platform; prefers Linux, proficient in macOS and Windows
+- **Tools**: Terraform, Ansible, Puppet, Docker, Grafana, ElasticSearch, VMware
+
+---
+
+## Skill Categories
+
+- **Systems Integration**: Connecting disparate hardware, software, APIs, and protocols into working systems
+- **Infrastructure & DevOps**: Linux, Bash, Docker, Terraform, Ansible, Puppet, Grafana, ElasticSearch, VMware, CI/CD
+- **Development**: Python, JavaScript/Node.js, REST APIs, Express.js, PWAs, Hexo, WordPress
+- **Hardware & IoT**: Raspberry Pi, Thunderbolt/PCIe, NFC, USB/HID, PCB design (Eagle), microcontrollers, sensors, drones
+- **Security**: HashiCorp Vault, TOTP/MFA, penetration testing, vulnerability assessment, fail2ban, SSH hardening
+- **AI/ML**: VQGAN, CLIP, TensorFlow, PyTorch, prompt engineering, GPU computing, NFT deployment
+- **Performance Engineering**: iperf3, benchmarking methodology, signal integrity, storage tiering, capacity planning
+- **Reverse Engineering**: USB HID descriptors, firmware binary analysis (binwalk/dd/od), protocol decoding, hardware teardown
+- **Automotive**: In-dash computing, vehicle electrical systems, telematics, EV conversion, engine diagnostics, fuel optimization
+- **Fabrication**: Woodworking, metalcasting, PCB design, electronics prototyping, kitchen/home renovation
+- **Design & Branding**: Affinity Photo/Designer, color theory, personal branding, PageSpeed optimization
+- **Business**: Company founding, product commercialization, consulting, regulatory navigation


### PR DESCRIPTION
Sydney Quidd  [4:43 PM]
Working on: I need to build a SKILLS.md file for myself, a human.  Please review my blog, https://chrisbergeron.com and derive the skills used for each project.   Order the skills by frequency in descending order.

[4:45 PM]Created ~/SKILLS.md. Analyzed 11 projects across 15 blog posts. Your top 5 skills by frequency:

    Linux System Administration (10 projects)
    Bash / Shell Scripting (8)
    Networking (7)
    JavaScript / Node.js (6)
    Hardware Tinkering / IoT (6)

The file includes a frequency-ranked table with project attributions, a project index, and a category summary. Note this only reflects what's published on the blog — your Docker, Traefik, Slack integrations, Mattermost, and Claude Code automation work aren't represented there yet. Tokesn: [in: 293 | out: 7,935]