### PR TITLE
Add /seg/dev and /seg/founder landing pages for Email 0

### DIFF
--- a/seg/dev/index.html
+++ b/seg/dev/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Got it — Chris Bergeron</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;600&family=Source+Code+Pro">
+<style>
+  body { font-family: 'Ubuntu', sans-serif; background: #1c1e26; color: #e0e0e0;
+         display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+  .card { max-width: 480px; padding: 3rem 2rem; text-align: center; }
+  h1 { font-size: 1.6rem; font-weight: 600; }
+  code { font-family: 'Source Code Pro', monospace; color: #8be9fd; }
+  a { color: #8be9fd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  p.sub { color: #9a9db0; }
+</style>
+</head>
+<body>
+<main class="card">
+  <h1>Got it, thanks. <code>// developer</code></h1>
+  <p class="sub">That's all I needed — no other info captured. Talk soon.</p>
+  <p><a href="https://chrisbergeron.com">&larr; back to chrisbergeron.com</a></p>
+</main>
+</body>
+</html>

--- a/seg/founder/index.html
+++ b/seg/founder/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Got it — Chris Bergeron</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;600&family=Source+Code+Pro">
+<style>
+  body { font-family: 'Ubuntu', sans-serif; background: #1c1e26; color: #e0e0e0;
+         display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+  .card { max-width: 480px; padding: 3rem 2rem; text-align: center; }
+  h1 { font-size: 1.6rem; font-weight: 600; }
+  code { font-family: 'Source Code Pro', monospace; color: #ffb86c; }
+  a { color: #8be9fd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  p.sub { color: #9a9db0; }
+</style>
+</head>
+<body>
+<main class="card">
+  <h1>Got it, thanks. <code>// founder</code></h1>
+  <p class="sub">That's all I needed — no other info captured. Talk soon.</p>
+  <p><a href="https://chrisbergeron.com">&larr; back to chrisbergeron.com</a></p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Self-segmentation landing pages referenced by the Email 0 re-engagement broadcast (UTM-tracked links). Simple 'Got it, thanks' confirmations, noindex, styled to match the blog's dark theme.

Part of the Email 0 send prep (chrisbergeron.com list re-engagement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)